### PR TITLE
Fix sendQueue usage example

### DIFF
--- a/examples/transactions.md
+++ b/examples/transactions.md
@@ -251,7 +251,7 @@ transactions.forEach(transaction => {
 })
 
 // Send transactions queue
-sendFunds.sendQueue(transactionEndpoint, explorerBasePath, transactions).then(response => {
+Exonum.sendQueue(transactionEndpoint, explorerBasePath, transactions).then(response => {
   // ...
 })
 ```


### PR DESCRIPTION
`sendQueue` is a function exported by Exonum module, not Message objects.