### PR TITLE
WIP: Transaction API syntax improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Remove `cutSignature` field from `serialize` method. ([#139][pr-139])
 * Rename `newMessage` method into `newTransaction`. ([#139][pr-139])
+* Rename `isInstanceofOfNewMessage` method into `isTransaction`. ([#139][pr-139])
+* Rename `isInstanceofOfNewArray` method into `isNewArray`. ([#139][pr-139])
 
 ## 0.14.0 (Oct 9, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.15.0 (Oct 9, 2018)
+
+* Remove `cutSignature` field from `serialize` method. ([#139][pr-139])
+* Rename `newMessage` method into `newTransaction`. ([#139][pr-139])
+
 ## 0.14.0 (Oct 9, 2018)
 
-* Update `Message` and `Precommit` serialization format. Change `newMessage` function syntax. ([#136][pr-136])
+* Update `Message` and `Precommit` serialization format. Change `newMessage` method syntax. ([#136][pr-136])
 Serialization format is changed in next release of the Exonum core.
 * Change `send` and `sendQueue` methods syntax. ([#136][pr-136])
 
@@ -155,6 +160,7 @@ matching [release 0.1][release-0.1] of the Exonum core repository.
 [release-0.7]: https://github.com/exonum/exonum/blob/master/CHANGELOG.md#07---2018-04-11
 [release-0.5]: https://github.com/exonum/exonum/blob/master/CHANGELOG.md#05---2018-01-30
 [release-0.1]: https://github.com/exonum/exonum/releases/tag/v0.1
+[pr-139]: https://github.com/exonum/exonum-client/pull/139
 [pr-138]: https://github.com/exonum/exonum-client/pull/138
 [pr-137]: https://github.com/exonum/exonum-client/pull/137
 [pr-136]: https://github.com/exonum/exonum-client/pull/136

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ Read more about [transactions][docs:architecture:transactions] in Exonum.
 An example of a transaction definition:
 
 ```javascript
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,
@@ -510,7 +510,7 @@ let sendFunds = Exonum.newMessage({
 })
 ```
 
-**Exonum.newMessage** function requires a single argument of `Object` type with next structure:
+**Exonum.newTransaction** function requires a single argument of `Object` type with next structure:
 
 | Property | Description | Type |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Library compatibility with Exonum core:
 
 | JavaScript light client | Exonum core |
 |---|---|
-| 0.14.0 | unreleased |
+| 0.15.0 | unreleased |
 | 0.13.0 | 0.9.* |
 | 0.10.2 | 0.8.* |
 | 0.9.0 | 0.7.* |
@@ -252,14 +252,13 @@ Check [serialization guide][docs:architecture:serialization] for details.
 Signature of `serialize` function:
 
 ```javascript
-type.serialize(data, cutSignature)
+type.serialize(data)
 ```
 
 | Argument | Description | Type |
 |---|---|---|
 | **data** | Data to serialize. | `Object` |
 | **type** | Definition of the field type. | [Custom data type](#define-data-type) or [transaction](#define-transaction). |
-| **cutSignature** | This flag is relevant only for **transaction** type. Specifies whether to not include a signature into the resulting byte array. *Optional.* | `Boolean` |
 
 An example of serialization into a byte array:
 
@@ -439,7 +438,7 @@ type.verifySignature(signature, publicKey, data)
 | Argument | Description | Type |
 |---|---|---|
 | **signature** | Signature as hexadecimal string. | `String` |
-| **publicKey** | Public key as hexadecimal string. | `String` |
+| **publicKey** | Author's public key as hexadecimal string. | `String` |
 | **data** | Data that has been signed. | `Object` |
 | **type** | Definition of the data type. | [Custom data type](#define-data-type) or [transaction](#define-transaction). |
 
@@ -518,8 +517,8 @@ let sendFunds = Exonum.newMessage({
 | **author** | Author's public key as hexadecimal string. | `String` |
 | **service_id** | [Service ID][docs:architecture:serialization:service-id]. | `Number` |
 | **message_id** | [Message ID][docs:architecture:serialization:message-id]. | `Number` |
-| **signature** | Signature as hexadecimal string. *Optional.* | `String` |
 | **fields** | List of fields. | `Array` |
+| **signature** | Signature as hexadecimal string. *Optional.* | `String` |
 
 Field structure is identical to field structure of [custom data type](#define-data-type).
 

--- a/examples/transactions.md
+++ b/examples/transactions.md
@@ -25,7 +25,7 @@ const data = {
 }
 
 // Serialize
-let buffer = sendFunds.serialize(data, true) // [0, 0, 128, 0, 130, 0, 146, 0, 0, 0, 245, 96, 42, 104, 104, 7, 251, 245, 75, 71, 235, 76, 150, 181, 186, 195, 53, 42, 68, 231, 80, 15, 110, 80, 123, 139, 78, 52, 19, 2, 199, 153, 247, 234, 143, 208, 44, 180, 28, 194, 205, 69, 253, 90, 220, 137, 202, 27, 246, 5, 178, 227, 31, 121, 106, 52, 23, 221, 188, 212, 163, 99, 70, 71, 232, 3, 0, 0, 0, 0, 0, 0]
+let buffer = sendFunds.serialize(data) // [0, 0, 128, 0, 130, 0, 146, 0, 0, 0, 245, 96, 42, 104, 104, 7, 251, 245, 75, 71, 235, 76, 150, 181, 186, 195, 53, 42, 68, 231, 80, 15, 110, 80, 123, 139, 78, 52, 19, 2, 199, 153, 247, 234, 143, 208, 44, 180, 28, 194, 205, 69, 253, 90, 220, 137, 202, 27, 246, 5, 178, 227, 31, 121, 106, 52, 23, 221, 188, 212, 163, 99, 70, 71, 232, 3, 0, 0, 0, 0, 0, 0]
 ```
 
 Read more about [serialization](../README.md#serialization).
@@ -62,7 +62,7 @@ const keyPair = {
 }
 
 // Sign the data
-let signature = sendFunds.sign(keyPair.secretKey, data) // 'c304505c8a46ca19454ff5f18335d520823cd0eb984521472ec7638b312a0f5b1180a3c39a50cbe3b68ed15023c6761ed1495da648c7fe484876f92a659ee10a'
+let signature = sendFunds.sign(keyPair.secretKey, data) // '9c7d0e518eb547292b6326faf191dcdb2d97a48a0d0570dec955d3cc3f3bd1e6f6ca4a306675fecc2c144c2b636dfb2254c958b77cd27ea2d17fa1462f67080c'
 ```
 
 Read more about [data signing](../README.md#sign-data).
@@ -148,7 +148,7 @@ const signature = sendFunds.sign(keyPair.secretKey, data)
 sendFunds.signature = signature
 
 // Get the hash
-let hash = sendFunds.hash(data) // '383900f7721acc9b7b45dd2495b28072d203b4e60137a95a94d98289970d5380'
+let hash = sendFunds.hash(data) // 'a0bd9da74d8329abe6ab7131a4a941e0bf6e5e2dded1197c6f75bbca42c81544'
 ```
 
 Read more about [hashes](../README.md#hash).

--- a/examples/transactions.md
+++ b/examples/transactions.md
@@ -6,7 +6,7 @@ An example of serialization into a byte array:
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'f5602a686807fbf54b47eb4c96b5bac3352a44e7500f6e507b8b4e341302c799',
   service_id: 130,
   message_id: 0,
@@ -36,7 +36,7 @@ An example of transaction signing:
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,
@@ -73,7 +73,7 @@ An example of signature verification:
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,
@@ -116,7 +116,7 @@ Example of calculation of a transaction hash:
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,
@@ -157,7 +157,7 @@ Read more about [hashes](../README.md#hash).
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,
@@ -195,7 +195,7 @@ sendFunds.send(explorerBasePath, data, keyPair.secretKey).then(response => {
 
 ```javascript
 // Define a transaction
-let sendFunds = Exonum.newMessage({
+let sendFunds = Exonum.newTransaction({
   author: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
   service_id: 130,
   message_id: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "exonum-client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exonum-client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Light Client for Exonum Blockchain",
   "main": "./lib/index.js",
   "engines": {

--- a/src/blockchain/merkle.js
+++ b/src/blockchain/merkle.js
@@ -1,6 +1,6 @@
 import bigInt from 'big-integer'
 import { isObject } from '../helpers'
-import { isInstanceofOfNewType } from '../types/generic'
+import { isType } from '../types/generic'
 import { validateHexadecimal, validateBytesArray } from '../types/validate'
 import { hexadecimalToUint8Array } from '../types/convert'
 import { hash } from '../crypto'
@@ -71,7 +71,7 @@ export function merkleProof (rootHash, count, proofNode, range, type) {
         if (!isObject(data)) {
           throw new TypeError('Invalid value of data parameter.')
         }
-        if (!isInstanceofOfNewType(type)) {
+        if (!isType(type)) {
           throw new TypeError('Invalid type of type parameter.')
         }
         element = data

--- a/src/blockchain/transport.js
+++ b/src/blockchain/transport.js
@@ -3,7 +3,7 @@ import { isObject } from '../helpers'
 import { hash } from '../crypto'
 import * as validate from '../types/validate'
 import { uint8ArrayToHexadecimal } from '../types/convert'
-import { isInstanceofOfNewMessage } from '../types/message'
+import { newMessage, isInstanceofOfNewMessage } from '../types/message'
 
 const ATTEMPTS = 10
 const ATTEMPT_TIMEOUT = 500
@@ -46,10 +46,19 @@ export function send (explorerBasePath, type, data, secretKey, attempts, timeout
     timeout = ATTEMPT_TIMEOUT
   }
 
-  type.signature = type.sign(secretKey, data)
+  // clone type
+  const typeCopy = newMessage(type)
 
-  const buffer = new Uint8Array(type.serialize(data))
-  const txBody = uint8ArrayToHexadecimal(buffer)
+  // sign transaction
+  typeCopy.signature = typeCopy.sign(secretKey, data)
+
+  // serialize transaction header and body
+  const buffer = typeCopy.serialize(data)
+
+  // convert buffer into hexadecimal string
+  const txBody = uint8ArrayToHexadecimal(new Uint8Array(buffer))
+
+  // get transaction hash
   const txHash = hash(buffer)
 
   return axios.post(`${explorerBasePath}`, {

--- a/src/blockchain/transport.js
+++ b/src/blockchain/transport.js
@@ -3,7 +3,7 @@ import { isObject } from '../helpers'
 import { hash } from '../crypto'
 import * as validate from '../types/validate'
 import { uint8ArrayToHexadecimal } from '../types/convert'
-import { newMessage, isInstanceofOfNewMessage } from '../types/message'
+import { newTransaction, isTransaction } from '../types/message'
 
 const ATTEMPTS = 10
 const ATTEMPT_TIMEOUT = 500
@@ -11,7 +11,7 @@ const ATTEMPT_TIMEOUT = 500
 /**
  * Send transaction to the blockchain
  * @param {string} explorerBasePath
- * @param {NewMessage} type
+ * @param {Transaction} type
  * @param {Object} data
  * @param {string} secretKey
  * @param {number} attempts
@@ -22,7 +22,7 @@ export function send (explorerBasePath, type, data, secretKey, attempts, timeout
   if (typeof explorerBasePath !== 'string') {
     throw new TypeError('Explorer base path endpoint of wrong data type is passed. String is required.')
   }
-  if (!isInstanceofOfNewMessage(type)) {
+  if (!isTransaction(type)) {
     throw new TypeError('Transaction of wrong type is passed.')
   }
   if (!isObject(data)) {
@@ -47,7 +47,7 @@ export function send (explorerBasePath, type, data, secretKey, attempts, timeout
   }
 
   // clone type
-  const typeCopy = newMessage(type)
+  const typeCopy = newTransaction(type)
 
   // sign transaction
   typeCopy.signature = typeCopy.sign(secretKey, data)

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -1,21 +1,21 @@
 import bigInt from 'big-integer'
 import sha from 'sha.js'
 import nacl from 'tweetnacl'
-import { isInstanceofOfNewType } from '../types/generic'
-import { isInstanceofOfNewMessage } from '../types/message'
+import { isType } from '../types/generic'
+import { isTransaction } from '../types/message'
 import * as validate from '../types/validate'
 import * as convert from '../types/convert'
 
 /**
  * Get SHA256 hash
  * @param {Object|Array|Uint8Array} data - object of NewType type or array of 8-bit integers
- * @param {NewType|NewMessage} [type] - optional, used only if data of {Object} type is passed
+ * @param {Type|Transaction} [type] - optional, used only if data of {Object} type is passed
  * @return {string}
  */
 export function hash (data, type) {
   let buffer
 
-  if (isInstanceofOfNewType(type) || isInstanceofOfNewMessage(type)) {
+  if (isType(type) || isTransaction(type)) {
     buffer = type.serialize(data)
   } else {
     if (type !== undefined) {
@@ -39,7 +39,7 @@ export function hash (data, type) {
  * Get ED25519 signature
  * @param {string} secretKey
  * @param {Object|Array} data - object of NewType type or array of 8-bit integers
- * @param {NewType|NewMessage} [type] - optional, used only if data of {Object} type is passed
+ * @param {Type|Transaction} [type] - optional, used only if data of {Object} type is passed
  * @return {string}
  */
 export function sign (secretKey, data, type) {
@@ -53,7 +53,7 @@ export function sign (secretKey, data, type) {
 
   secretKeyUint8Array = convert.hexadecimalToUint8Array(secretKey)
 
-  if (isInstanceofOfNewType(type) || isInstanceofOfNewMessage(type)) {
+  if (isType(type) || isTransaction(type)) {
     buffer = new Uint8Array(type.serialize(data))
   } else {
     if (type !== undefined) {
@@ -79,7 +79,7 @@ export function sign (secretKey, data, type) {
  * @param {string} signature
  * @param {string} publicKey
  * @param {Object|Array} data - object of NewType type or array of 8-bit integers
- * @param {NewType|NewMessage} [type] - optional, used only if data of {Object} type is passed
+ * @param {Type|Transaction} [type] - optional, used only if data of {Object} type is passed
  * @return {boolean}
  */
 export function verifySignature (signature, publicKey, data, type) {
@@ -99,7 +99,7 @@ export function verifySignature (signature, publicKey, data, type) {
 
   publicKeyUint8Array = convert.hexadecimalToUint8Array(publicKey)
 
-  if (isInstanceofOfNewType(type) || isInstanceofOfNewMessage(type)) {
+  if (isType(type) || isTransaction(type)) {
     buffer = new Uint8Array(type.serialize(data))
   } else if (type === undefined) {
     if (data instanceof Uint8Array) {

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -53,23 +53,20 @@ export function sign (secretKey, data, type) {
 
   secretKeyUint8Array = convert.hexadecimalToUint8Array(secretKey)
 
-  if (isInstanceofOfNewType(type)) {
+  if (isInstanceofOfNewType(type) || isInstanceofOfNewMessage(type)) {
     buffer = new Uint8Array(type.serialize(data))
   } else {
-    if (isInstanceofOfNewMessage(type)) {
-      buffer = new Uint8Array(type.serialize(data, true))
+    if (type !== undefined) {
+      throw new TypeError('Wrong type of data.')
+    }
+
+    if (data instanceof Uint8Array) {
+      buffer = data
     } else {
-      if (type !== undefined) {
-        throw new TypeError('Wrong type of data.')
+      if (!Array.isArray(data)) {
+        throw new TypeError('Invalid data parameter.')
       }
-      if (data instanceof Uint8Array) {
-        buffer = data
-      } else {
-        if (!Array.isArray(data)) {
-          throw new TypeError('Invalid data parameter.')
-        }
-        buffer = new Uint8Array(data)
-      }
+      buffer = new Uint8Array(data)
     }
   }
   signature = nacl.sign.detached(buffer, secretKeyUint8Array)
@@ -102,10 +99,8 @@ export function verifySignature (signature, publicKey, data, type) {
 
   publicKeyUint8Array = convert.hexadecimalToUint8Array(publicKey)
 
-  if (isInstanceofOfNewType(type)) {
+  if (isInstanceofOfNewType(type) || isInstanceofOfNewMessage(type)) {
     buffer = new Uint8Array(type.serialize(data))
-  } else if (isInstanceofOfNewMessage(type)) {
-    buffer = new Uint8Array(type.serialize(data, true))
   } else if (type === undefined) {
     if (data instanceof Uint8Array) {
       buffer = data

--- a/src/types/array.js
+++ b/src/types/array.js
@@ -37,6 +37,6 @@ export function newArray (arr) {
  * @param {Object} arr
  * @returns {boolean}
  */
-export function isInstanceofOfNewArray (arr) {
+export function isNewArray (arr) {
   return arr instanceof NewArray
 }

--- a/src/types/generic.js
+++ b/src/types/generic.js
@@ -6,7 +6,7 @@ import { String } from './primitive'
  * @constructor
  * @param {Object} type
  */
-class NewType {
+class Type {
   constructor (type) {
     type.fields.forEach(field => {
       if (field.name === undefined) {
@@ -31,7 +31,7 @@ class NewType {
   }
 
   /**
-   * Serialize data of NewType type into array of 8-bit integers
+   * Serialize data into array of 8-bit integers
    * @param {Object} data
    * @returns {Array}
    */
@@ -71,21 +71,21 @@ class NewType {
 }
 
 /**
- * Create element of NewType class
+ * Create element of Type class
  * @param {Object} type
- * @returns {NewType}
+ * @returns {Type}
  */
 export function newType (type) {
-  return new NewType(type)
+  return new Type(type)
 }
 
 /**
- * Check if passed object is of type NewType
+ * Check if passed object is of type Type
  * @param {Object} type
  * @returns {boolean}
  */
-export function isInstanceofOfNewType (type) {
-  return type instanceof NewType
+export function isType (type) {
+  return type instanceof Type
 }
 
 /**
@@ -94,7 +94,7 @@ export function isInstanceofOfNewType (type) {
  * @returns {boolean}
  */
 export function fieldIsFixed (field) {
-  if (isInstanceofOfNewType(field.type)) {
+  if (isType(field.type)) {
     return newTypeIsFixed(field.type)
   }
 

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -47,10 +47,9 @@ class NewMessage {
   /**
    * Serialize data of NewMessage type into array of 8-bit integers
    * @param {Object} data
-   * @param {boolean} [cutSignature] - optional parameter used flag that signature should not be appended to serialized data
    * @returns {Array}
    */
-  serialize (data, cutSignature) {
+  serialize (data) {
     const MessageHead = newType({
       fields: [
         { name: 'author', type: PublicKey },
@@ -71,7 +70,7 @@ class NewMessage {
 
     let messageBody = serialization.serialize([], 0, data, this)
 
-    if (cutSignature !== true) {
+    if (this.signature) {
       Digest.serialize(this.signature, messageBody, messageBody.length)
     }
 

--- a/src/types/message.js
+++ b/src/types/message.js
@@ -70,7 +70,7 @@ class Transaction extends Message {
       ]
     })
 
-    let head = Head.serialize({
+    const head = Head.serialize({
       author: this.author,
       cls: this.cls,
       type: this.type,
@@ -78,7 +78,7 @@ class Transaction extends Message {
       message_id: this.message_id
     })
 
-    let body = serialization.serialize([], 0, data, this)
+    const body = serialization.serialize([], 0, data, this)
 
     if (this.signature) {
       Digest.serialize(this.signature, body, body.length)
@@ -175,13 +175,13 @@ class Precommit extends Message {
       ]
     })
 
-    let head = Head.serialize({
+    const head = Head.serialize({
       author: this.author,
       cls: this.cls,
       type: this.type
     })
 
-    let body = serialization.serialize([], 0, data, this, true)
+    const body = serialization.serialize([], 0, data, this, true)
 
     return head.concat(body)
   }

--- a/src/types/serialization.js
+++ b/src/types/serialization.js
@@ -129,11 +129,7 @@ export function serialize (buffer, shift, data, type, isTransactionBody) {
 
     if (isType(field.type)) {
       buffer = serializeInstanceofOfNewType(buffer, nestedShift, from, value, field.type)
-      if (fieldIsFixed(field)) {
-        localShift += field.type.size()
-      } else {
-        localShift += POINTER_SIZE
-      }
+      localShift += fieldIsFixed(field) ? field.type.size() : POINTER_SIZE
     } else if (isNewArray(field.type)) {
       buffer = serializeInstanceofOfNewArray(buffer, nestedShift, from, value, field.type)
       localShift += field.type.size()

--- a/test/sources/blockchain.js
+++ b/test/sources/blockchain.js
@@ -245,7 +245,7 @@ describe('Send transaction to the blockchain', function () {
     publicKey: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
     secretKey: '978e3321bd6331d56e5f4c2bdb95bf471e95a77a6839e68d4241e7b0932ebe2bfa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a'
   }
-  const sendFunds = Exonum.newMessage({
+  const sendFunds = Exonum.newTransaction({
     author: keyPair.publicKey,
     service_id: 130,
     message_id: 0,
@@ -531,7 +531,7 @@ describe('Send multiple transactions to the blockchain', function () {
     publicKey: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
     secretKey: '978e3321bd6331d56e5f4c2bdb95bf471e95a77a6839e68d4241e7b0932ebe2bfa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a'
   }
-  let sendFunds = Exonum.newMessage({
+  let sendFunds = Exonum.newTransaction({
     author: keyPair.publicKey,
     service_id: 130,
     message_id: 0,

--- a/test/sources/cryptography.js
+++ b/test/sources/cryptography.js
@@ -21,12 +21,12 @@ describe('Check cryptography', function () {
       expect(hash).to.equal(cryptographyMock.type2.hash)
     })
 
-    it('should return hash of data of newMessage type', function () {
+    it('should return hash of data of Transaction type', function () {
       const hash = Exonum.hash(cryptographyMock.type3.data, schema.getMessage('type3'))
       expect(hash).to.equal(cryptographyMock.type3.hash)
     })
 
-    it('should return hash of data of newMessage type using built-in method', function () {
+    it('should return hash of data of Transaction type using built-in method', function () {
       const hash = schema.getMessage('type4').hash(cryptographyMock.type4.data)
       expect(hash).to.equal(cryptographyMock.type4.hash)
     })
@@ -47,7 +47,7 @@ describe('Check cryptography', function () {
       })
     })
 
-    it('should throw error when data of invalid NewMessage type', function () {
+    it('should throw error when data of invalid Transaction type', function () {
       expect(() => Exonum.hash(undefined, schema.getMessage('type3')))
         .to.throw(TypeError, 'Cannot read property \'name\' of undefined');
 
@@ -69,12 +69,12 @@ describe('Check cryptography', function () {
       expect(signature).to.equal(cryptographyMock.type6.signed)
     })
 
-    it('should return signature of the data of NewMessage type', function () {
+    it('should return signature of the data of Transaction type', function () {
       const signature = Exonum.sign(cryptographyMock.type7.secretKey, cryptographyMock.type7.data, schema.getMessage('type7'))
       expect(signature).to.equal(cryptographyMock.type7.signed)
     })
 
-    it('should return signature of the data of NewMessage type using built-in method', function () {
+    it('should return signature of the data of Transaction type using built-in method', function () {
       const signature = schema.getMessage('type8').sign(cryptographyMock.type8.secretKey, cryptographyMock.type8.data)
       expect(signature).to.equal(cryptographyMock.type8.signed)
     })
@@ -90,7 +90,7 @@ describe('Check cryptography', function () {
         .to.throw(TypeError, 'Field firstName is not defined.')
     })
 
-    it('should throw error when the data parameter of wrong NewMessage type', function () {
+    it('should throw error when the data parameter of wrong Transaction type', function () {
       expect(() => Exonum.sign(invalidCryptographyMock.type7.secretKey, invalidCryptographyMock.type7.data, schema.getMessage('type7')))
         .to.throw(TypeError, 'Field name is not defined.')
     })
@@ -170,10 +170,10 @@ describe('Check cryptography', function () {
       expect(User.verifySignature(signature, publicKey, userData)).to.be.true
     })
 
-    it('should verify signature of the data of NewMessage type and return true', function () {
+    it('should verify signature of the data of Transaction type and return true', function () {
       const publicKey = 'f5864ab6a5a2190666b47c676bcf15a1f2f07703c5bcafb5749aa735ce8b7c36'
       const signature = '856c7f680dd59fd0259c15add9e4cd558ec8ce375edb5efc7bbd646426d81f2b5cfa6eda76ea074646df27e4a2baf6831c5cddeb0ceb35c8c559392bf4427b04'
-      const CustomMessage = Exonum.newMessage({
+      const CustomMessage = Exonum.newTransaction({
         author: publicKey,
         service_id: 1,
         message_id: 0,
@@ -194,10 +194,10 @@ describe('Check cryptography', function () {
       expect(Exonum.verifySignature(signature, publicKey, messageData, CustomMessage)).to.be.true
     })
 
-    it('should verify signature of the data of NewMessage type using built-in method and return true', function () {
+    it('should verify signature of the data of Transaction type using built-in method and return true', function () {
       const publicKey = 'f5864ab6a5a2190666b47c676bcf15a1f2f07703c5bcafb5749aa735ce8b7c36'
       const signature = '856c7f680dd59fd0259c15add9e4cd558ec8ce375edb5efc7bbd646426d81f2b5cfa6eda76ea074646df27e4a2baf6831c5cddeb0ceb35c8c559392bf4427b04'
-      const CustomMessage = Exonum.newMessage({
+      const CustomMessage = Exonum.newTransaction({
         author: publicKey,
         service_id: 1,
         message_id: 0,
@@ -266,10 +266,10 @@ describe('Check cryptography', function () {
         .to.throw(TypeError, 'Field firstName is not defined.')
     })
 
-    it('should throw error when the data parameter is of wrong NewMessage type', function () {
+    it('should throw error when the data parameter is of wrong Transaction type', function () {
       const publicKey = 'f5864ab6a5a2190666b47c676bcf15a1f2f07703c5bcafb5749aa735ce8b7c36'
       const signature = '24a5224702d670c95a78ef1f753c9e6e698da5b2a2c52dcc51b5bf9e556e717fb763b1a5e78bd39e5369a139ab68ae50dd19a129038e8da3af30985f09549500'
-      const CustomMessage = Exonum.newMessage({
+      const CustomMessage = Exonum.newTransaction({
         author: publicKey,
         service_id: 1,
         message_id: 0,

--- a/test/sources/data_schema/dataSchema.js
+++ b/test/sources/data_schema/dataSchema.js
@@ -17,7 +17,7 @@ export default class DataSchema {
           field.type = this.getTypeOrArray(field.type)
         })
         if (!item.as || item.as === 'type') this.types[key] = Exonum.newType(item)
-        if (item.as === 'message') this.messages[key] = Exonum.newMessage(item)
+        if (item.as === 'message') this.messages[key] = Exonum.newTransaction(item)
       } else {
         if (item.as === 'array') {
           item.type = this.getTypeOrArray(item.type)

--- a/test/sources/readme.js
+++ b/test/sources/readme.js
@@ -36,7 +36,7 @@ describe('Examples from README.md', function () {
       publicKey: 'fa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a',
       secretKey: '978e3321bd6331d56e5f4c2bdb95bf471e95a77a6839e68d4241e7b0932ebe2bfa7f9ee43aff70c879f80fa7fd15955c18b98c72310b09e7818310325050cf7a'
     }
-    const SendFunds = Exonum.newMessage({
+    const SendFunds = Exonum.newTransaction({
       author: keyPair.publicKey,
       service_id: 130,
       message_id: 0,

--- a/test/sources/readme.js
+++ b/test/sources/readme.js
@@ -52,9 +52,24 @@ describe('Examples from README.md', function () {
       amount: 50
     }
     const buffer = [250, 127, 158, 228, 58, 255, 112, 200, 121, 248, 15, 167, 253, 21, 149, 92, 24, 185, 140, 114, 49, 11, 9, 231, 129, 131, 16, 50, 80, 80, 207, 122, 0, 0, 130, 0, 0, 0, 103, 82, 190, 136, 35, 20, 245, 187, 188, 154, 106, 242, 174, 99, 79, 192, 112, 56, 88, 74, 74, 119, 81, 14, 165, 236, 237, 69, 245, 77, 192, 48, 245, 134, 74, 182, 165, 162, 25, 6, 102, 180, 124, 103, 107, 207, 21, 161, 242, 240, 119, 3, 197, 188, 175, 181, 116, 154, 167, 53, 206, 139, 124, 54, 50, 0, 0, 0, 0, 0, 0, 0]
+    const signature = '9c7d0e518eb547292b6326faf191dcdb2d97a48a0d0570dec955d3cc3f3bd1e6f6ca4a306675fecc2c144c2b636dfb2254c958b77cd27ea2d17fa1462f67080c'
+    const hash = 'a0bd9da74d8329abe6ab7131a4a941e0bf6e5e2dded1197c6f75bbca42c81544'
 
     it('should serialize transaction', function () {
-      expect(SendFunds.serialize(data, true)).to.deep.equal(buffer)
+      expect(SendFunds.serialize(data)).to.deep.equal(buffer)
+    })
+
+    it('should sign transaction', function () {
+      expect(SendFunds.sign(keyPair.secretKey, data)).to.equal(signature)
+    })
+
+    it('should verify transaction signature', function () {
+      expect(SendFunds.verifySignature(signature, keyPair.publicKey, data)).to.be.true
+    })
+
+    it('should get transaction hash', function () {
+      SendFunds.signature = signature
+      expect(SendFunds.hash(data)).to.equal(hash)
     })
   })
 

--- a/test/sources/serialization.js
+++ b/test/sources/serialization.js
@@ -14,13 +14,13 @@ describe('Serialize data into array of 8-bit integers', function () {
     expect(buffer).to.deep.equal(serializationMock.wallet.serialized)
   })
 
-  it('should serialize data of newMessage type and return array of 8-bit integers', function () {
+  it('should serialize data of Transaction type and return array of 8-bit integers', function () {
     const buffer = schema.getMessage('addUser').serialize(serializationMock.user.data)
 
     expect(buffer).to.deep.equal(serializationMock.user.serialized)
   })
 
-  it('should serialize data of newMessage type with nester array and return array of 8-bit integers', function () {
+  it('should serialize data of Transaction type with nester array and return array of 8-bit integers', function () {
     const buffer = schema.getMessage('addUserArray').serialize(serializationMock.userArray.data)
 
     expect(buffer).to.deep.equal(serializationMock.userArray.serialized)


### PR DESCRIPTION
Method`newMessage` has been renamed into `newTransaction` to avoid confusion in terms.
Now `Transaction` is extended from`Message` class.