### PR TITLE
Support unhashed `MapProof` keys [ECR-4147]

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ The `MapProof` class is used to validate proofs for Merkelized maps.
 | **KeyType** | Data type for keys in the Merkelized map. | [Custom](#define-data-type) or built-in data type |
 | **ValueType** | Data type for values in the Merkelized map. | [Custom data type](#define-data-type) |
 
+Keys in a map proof can either be *hashed* (which is the default option)
+or *raw*. To obtain a raw version for `KeyType`, use `MapProof.rawKey(KeyType)`.
+The key type is determined by the service developer when the service schema
+is created. Raw keys minimize the amount of hashing, but require that the underlying type
+has fixed-width binary serialization.
+
 The returned object has the following fields:
 
 | Field | Description | Type |

--- a/examples/map-proof.js
+++ b/examples/map-proof.js
@@ -4,6 +4,7 @@
 'use strict'
 
 const Exonum = require('..')
+const { MapProof, PublicKey } = Exonum
 const { expect } = require('chai')
 const { Type, Field } = require('protobufjs/light')
 
@@ -52,7 +53,7 @@ let proof = {
       missing: '69a5411f3ec4c2cd7e83bf61130e15654d69b76585dcca6e1dcc986a50b96cad'
     }
   ],
-  'proof': [
+  proof: [
     {
       path: '0000110110110010100111000100010110011110110000100010100001000101010000110001110001010110010001111011011101000111101100111010010000010110011110111011110111001111001110110000101111101100111101100001000110010101101101010001111000111101000111110111110011000101',
       hash: '42458b0cf398d03cefb02fe31919b4bbe6ee6c68a79c49bea7c80a0b0bef3936'
@@ -85,17 +86,19 @@ let proof = {
 }
 
 // Temporary hack to convert `PublicKey`s into the form compatible with the Protobuf reader.
-proof.entries.forEach(({ value }) => {
-  if (value && value.pub_key) {
-    value.pub_key = {
-      data: Buffer.from(value.pub_key, 'hex')
+function convertPublicKey (wallet) {
+  if (wallet && wallet.pub_key) {
+    wallet.pub_key = {
+      data: Buffer.from(wallet.pub_key, 'hex')
     }
   }
-})
+}
+
+proof.entries.forEach(({ value }) => convertPublicKey(value))
 
 // Create a `MapProof` instance. The constructor will throw an error if
 // the supplied JSON is malformed.
-proof = new Exonum.MapProof(proof, Exonum.PublicKey, Wallet)
+proof = new MapProof(proof, PublicKey, Wallet)
 expect(proof.entries.size).to.equal(2)
 expect(proof.missingKeys.size).to.equal(2)
 
@@ -114,3 +117,86 @@ for (let missingKey of proof.missingKeys) {
 // (usually, a `state_hash` field in the block header). Here, we just compare
 // it to the reference value for simplicity.
 expect(proof.merkleRoot).to.equal('22e3fa8457f2226546f8919ef22bba7853ddc55e221c95644daf21970e8ea8a6')
+
+// Perform the same task, but for raw (unhashed) keys. These keys may be used
+// with certain key types (e.g., `PublicKey`) to minimize the amount of hashing.
+//
+// This proof JSON is obtained using the following commands:
+//
+//   cd integration-tests
+//   cargo run &
+//   curl http://localhost:8000/wallets/random-raw?seed=1337&wallets=20&wallets_in_proof=2
+proof = {
+  entries: [
+    {
+      key: '049b1598a5b417fcd53e318bc90322b72c52bd771ff3febb3d53d36b77329ada',
+      value: {
+        pub_key: '049b1598a5b417fcd53e318bc90322b72c52bd771ff3febb3d53d36b77329ada',
+        name: '049b1598',
+        balance: 69049252,
+        uniq_id: 'beb5bee7-ac51-c829-1b16-e8b77a12d371'
+      }
+    },
+    {
+      missing: 'c6e167e6914c68fe9cb6d02e72ff4c8ecfe8fa1696625e4b1f89eb6597b1c16a'
+    },
+    {
+      key: 'c1608da6fe83023f95c1d9d31d070c4e70b93059f1a298b1a02e85eb4414c855',
+      'value': {
+        pub_key: 'c1608da6fe83023f95c1d9d31d070c4e70b93059f1a298b1a02e85eb4414c855',
+        name: 'c1608da6',
+        balance: 3986358255,
+        uniq_id: '0621b404-80c5-bf18-04c1-6c466054f28a'
+      }
+    },
+    {
+      missing: '69a5411f3ec4c2cd7e83bf61130e15654d69b76585dcca6e1dcc986a50b96cad'
+    }
+  ],
+  proof: [
+    {
+      path: '000',
+      hash: '990c60568f8aaba6f42fa082c3465e46d6fe294396eb545ba4d3b0696e3f1f86'
+    },
+    {
+      path: '0011',
+      hash: '89d4d997f806056d9d390a4e70ab4054d652a1eed345723b9af44e5fe87a309b'
+    },
+    {
+      path: '0100101001110111101001000111001011101100001110010000101001110001011100011110110010111111001001001001010110001000101110011001000100100000011101011001010110001010000001111010000011010011010010000111110111100111110100100111010110111011010010011001100101011010',
+      hash: 'eecd7bf7dc58b367dd059c8f6c13c8b7674c244e2f22e03af91c7d45bc4e85fc'
+    },
+    {
+      path: '0110001100101011001000110110101110110111101100100101011011011111101010001010000100110011001000110011100111000100001001110110011100000101001110100011101110101010111101001110011011111111111001101000001100111000101011101010010000011000011000000110001111101011',
+      hash: 'd156aba4c4e5c63124ac52295466e935ba5d2282a64082c85841e32bbf5b4c97'
+    },
+    {
+      path: '0110100101001001110100110101000110101000111000000011000100111111111111100010100001001101111111011010011111010001011011011100010001011100101010011111011011011110101011101010001101110100110001000101011110011101101001000101100011000011111110010011101010111100',
+      hash: 'a22631cc982f32971febdb758163585fcba1fa60ac247cdca9d7def498ded678'
+    },
+    {
+      path: '0111101011101010010101110011000111011111000001000001111011110100110010101101111101110101001010110001001010111100001011001010011111111110001100111001001011001001101111110001010010101000100010111011101100110010000101110101111100101000110010101100100100001100',
+      hash: '6843d354b2b761a346c5e341128b30beb8c5958783ac131de60d1352741d813c'
+    },
+    {
+      path: '1000011110011001110000000100011001011000011110011011000110110110011000111010111100001010010010001011001011111110110000100000000110110110110000101010100011111010111000010111101110010100010011011101000000011101011101011011011100100000111010000001010000001101',
+      hash: 'dd0a44b99e08e3f7eeb17c2f14487ae5ec764adbc6245ef09a7e0c6bfd89b680'
+    },
+    {
+      path: '1001111101100101110010000101111110001110111001111101001001000001100111100101001110101101001100101101001001011101000100101101001101001110010100100011001010011100110011110001111101000110010011001100111011011100011110110101100001100100111011000010100100101010',
+      hash: '3bb6a394e0f69404bf8594f5fc42a2a5275b1d98f86bb766e4091597f4df7803'
+    },
+    {
+      path: '11',
+      hash: '32a61b662d8a1720622f524162323f2c01bb6e706163e03a0724cfaa94814ebf'
+    }
+  ]
+}
+
+proof.entries.forEach(({ value }) => convertPublicKey(value))
+
+// Create a `MapProof` instance. Note the use of `MapProof.rawKey`.
+proof = new MapProof(proof, MapProof.rawKey(PublicKey), Wallet)
+expect(proof.entries.size).to.equal(2)
+expect(proof.missingKeys.size).to.equal(2)
+expect(proof.merkleRoot).to.equal('facb561c29cc1aeac8bdd9a101a6644f8e49fa24a23c835723e8039e00979949')

--- a/package-lock.json
+++ b/package-lock.json
@@ -3951,12 +3951,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3971,17 +3973,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4098,7 +4103,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4110,6 +4116,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4124,6 +4131,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4131,12 +4139,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4155,6 +4165,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4244,7 +4255,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4256,6 +4268,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4377,6 +4390,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/blockchain/merkle-patricia.js
+++ b/src/blockchain/merkle-patricia.js
@@ -1,6 +1,6 @@
 import binarySearch from 'binary-search'
 
-import { hash } from '../crypto'
+import { hash, HASH_LENGTH } from '../crypto'
 import { Hash } from '../types/hexadecimal'
 import { BLOB_PREFIX, MAP_PREFIX, MAP_BRANCH_PREFIX } from './constants'
 import ProofPath from './ProofPath'
@@ -11,6 +11,28 @@ import { hexadecimalToUint8Array } from '../types'
  * map index.
  */
 export class MapProof {
+  /**
+   * Converts a key type to a raw representation, in which keys are not hashed before
+   * Merkle Patricia tree construction.
+   *
+   * @param keyType
+   */
+  static rawKey (keyType) {
+    if (typeof keyType.serialize !== 'function') {
+      throw new TypeError('Invalid key type; pass a type with a `serialize` function')
+    }
+
+    return {
+      hash (data) {
+        const bytes = keyType.serialize(data, [], 0)
+        if (bytes.length !== HASH_LENGTH) {
+          throw new Error(`Invalid raw key; raw keys should have ${HASH_LENGTH}-byte serialization`)
+        }
+        return bytes
+      }
+    }
+  }
+
   /**
    * Creates a new instance of a proof.
    *
@@ -29,8 +51,11 @@ export class MapProof {
     this.proof = parseProof(json.proof)
     this.entries = parseEntries(json.entries, keyType, valueType)
 
-    if (!keyType || typeof keyType.serialize !== 'function') {
-      throw new TypeError('No `serialize` method in the key type')
+    if (!keyType) {
+      throw new TypeError('No key type provided')
+    }
+    if (typeof keyType.serialize !== 'function' && typeof keyType.hash !== 'function') {
+      throw new TypeError('No `serialize` or `hash` method in the key type')
     }
     this.keyType = keyType
 
@@ -98,8 +123,14 @@ function parseEntries (entries, keyType, valueType) {
     const keyBytes = (typeof keyType.hash === 'function')
       ? keyType.hash(data)
       : hash(keyType.serialize(data, [], 0))
-    const bytes = hexadecimalToUint8Array(keyBytes)
-    return new ProofPath(new Uint8Array(bytes))
+
+    let bytes
+    if (typeof keyBytes === 'string') {
+      bytes = hexadecimalToUint8Array(keyBytes)
+    } else {
+      bytes = new Uint8Array(keyBytes)
+    }
+    return new ProofPath(bytes)
   }
 
   if (!Array.isArray(entries)) {

--- a/src/blockchain/merkle-patricia.js
+++ b/src/blockchain/merkle-patricia.js
@@ -18,7 +18,7 @@ export class MapProof {
    * @param keyType
    */
   static rawKey (keyType) {
-    if (typeof keyType.serialize !== 'function') {
+    if (!keyType || typeof keyType.serialize !== 'function') {
       throw new TypeError('Invalid key type; pass a type with a `serialize` function')
     }
 

--- a/test/sources/merkle-patricia-proof.js
+++ b/test/sources/merkle-patricia-proof.js
@@ -615,6 +615,25 @@ describe('MapProof', () => {
       expect(proof.merkleRoot).to.equal(expHash)
     })
 
+    it('should calculate hash for a single node with raw key', () => {
+      const key = '34264463370758a230017c5635678c9a39fa90a5081ec08f85de6c56243f4011'
+      const proof = new MapProof({
+        entries: [
+          { key, value: 100 }
+        ],
+        proof: []
+      }, MapProof.rawKey(PublicKey), Uint16)
+
+      const nodeHash = streamHash(
+        [4, 1],
+        key,
+        [0],
+        streamHash([0, 100, 0]) // Blob marker + little-endian encoding of the value
+      )
+      const expHash = streamHash([3], nodeHash)
+      expect(proof.merkleRoot).to.equal(expHash)
+    })
+
     it('should calculate hash for a single hashed node', () => {
       const key = '34264463370758a230017c5635678c9a39fa90a5081ec08f85de6c56243f4011'
       const proof = new MapProof({

--- a/test/sources/merkle-patricia-proof.js
+++ b/test/sources/merkle-patricia-proof.js
@@ -685,6 +685,25 @@ describe('MapProof', () => {
     })
   })
 
+  describe('MapProof.rawKey', () => {
+    it('should throw if incorrect input is passed', () => {
+      const incorrectInputs = [undefined, null, {}, true, 1, 'string']
+      incorrectInputs.forEach((input) => {
+        expect(() => MapProof.rawKey(input)).to.throw(TypeError, 'Invalid key type')
+      })
+    })
+
+    it('should throw if serialization has unexpected length', () => {
+      const BogusKey = MapProof.rawKey({
+        // `uint8` serialization
+        serialize (data) {
+          return [data % 256]
+        }
+      })
+      expect(() => BogusKey.hash(1)).to.throw('Invalid raw key')
+    })
+  })
+
   function testValidSample (sampleName) {
     it(`should work on sample ${sampleName}`, () => {
       const sample = samples[sampleName]


### PR DESCRIPTION
This PR introduces first-class support of raw (unhashed) keys for `MapProof`s.

See also: https://jira.bf.local/browse/ECR-4147