### PR TITLE
Update `MapProof` hashing [ECR-4171]

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-exonum = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "ac7f24a4" }
-exonum-derive = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "ac7f24a4" }
-exonum-merkledb = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "ac7f24a4" }
-exonum-proto = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "ac7f24a4" }
+exonum = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "42fd92b6" }
+exonum-derive = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "42fd92b6" }
+exonum-merkledb = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "42fd92b6" }
+exonum-proto = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "42fd92b6" }
 
 actix-web = { version = "0.7.19", default-features = false }
 backtrace = "=0.3.40" # Last Rust 1.36-compatible version
@@ -26,4 +26,4 @@ serde_derive = "1.0"
 uuid = "0.8.1"
 
 [build-dependencies]
-exonum-build = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "ac7f24a4" }
+exonum-build = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "42fd92b6" }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -24,7 +24,7 @@ use exonum::{
     crypto::{gen_keypair_from_seed, hash, Hash, PublicKey, SecretKey, Seed, HASH_SIZE},
     helpers::{Height, Round, ValidatorId},
     merkledb::{
-        access::AccessExt,
+        access::CopyAccessExt,
         indexes::proof_map::{Hashed, Raw, ToProofPath},
         BinaryValue, Database, ListProof, MapProof, ObjectHash, SystemSchema, TemporaryDB,
     },

--- a/src/blockchain/merkle-patricia.js
+++ b/src/blockchain/merkle-patricia.js
@@ -214,8 +214,8 @@ function serializeBranchNode (leftHash, rightHash, leftPath, rightPath) {
 }
 
 function serializeIsolatedNode (path, hash) {
-  // `1, ...path.key, 0` is the old `ProofPath` serialization for terminal paths.
-  const buffer = [MAP_BRANCH_PREFIX, 1, ...path.key, 0]
+  const buffer = [MAP_BRANCH_PREFIX]
+  path.serialize(buffer)
   Hash.serialize(hash, buffer, buffer.length)
   return buffer
 }

--- a/test/sources/data/map-proof.json
+++ b/test/sources/data/map-proof.json
@@ -112,7 +112,7 @@
   "valid-single-wallet": {
     "expected": {
       "valueType": "Wallet",
-      "merkleRoot": "57b460754a95c6b50d23db1041a0b105b04be474325f7e37ac807857c3933b09",
+      "merkleRoot": "b662e771af954695cd8ab0df69ad66a1e064939e547fdd209a28217055f9a34a",
       "entries": [
         [
           "097bae292e571a32d86dc5e31a19b04f086b51b5d27b0455ad514931e8a7261d", {

--- a/test/sources/merkle-patricia-proof.js
+++ b/test/sources/merkle-patricia-proof.js
@@ -606,9 +606,9 @@ describe('MapProof', () => {
       }, PublicKey, Uint16)
 
       const nodeHash = streamHash(
-        [4, 1],
+        [4], // domain separation tag
+        [128, 2], // LEB128 encoding of 256 (bits in the path)
         streamHash(key),
-        [0],
         streamHash([0, 100, 0]) // Blob marker + little-endian encoding of the value
       )
       const expHash = streamHash([3], nodeHash)
@@ -625,9 +625,8 @@ describe('MapProof', () => {
       }, MapProof.rawKey(PublicKey), Uint16)
 
       const nodeHash = streamHash(
-        [4, 1],
+        [4, 128, 2], // Marker + LEB128(256)
         key,
-        [0],
         streamHash([0, 100, 0]) // Blob marker + little-endian encoding of the value
       )
       const expHash = streamHash([3], nodeHash)
@@ -647,9 +646,8 @@ describe('MapProof', () => {
       }, PublicKey, Uint16)
 
       const nodeHash = streamHash(
-        [4, 1],
+        [4, 128, 2],
         Exonum.PublicKey.serialize(key, [], 0),
-        [0],
         key
       )
       const expHash = streamHash([3], nodeHash)


### PR DESCRIPTION
This PR updates `MapProof` hashing according to changes in the Exonum core.

See: https://jira.bf.local/browse/ECR-4171