### PR TITLE
Test client with 1.0.0-rc.1 [ECR-4235]

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-exonum = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "86520c29" }
-exonum-derive = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "86520c29" }
-exonum-merkledb = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "86520c29" }
-exonum-proto = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "86520c29" }
+exonum = "=1.0.0-rc.1"
+exonum-derive = "=1.0.0-rc.1"
+exonum-merkledb = "=1.0.0-rc.1"
+exonum-proto = "=1.0.0-rc.1"
 
 actix-web = { version = "0.7.19", default-features = false }
 backtrace = "=0.3.40" # Last Rust 1.36-compatible version
@@ -26,4 +26,4 @@ serde_derive = "1.0"
 uuid = "0.8.1"
 
 [build-dependencies]
-exonum-build = { version = "0.13.0-rc.2", git = "https://github.com/exonum/exonum", rev = "86520c29" }
+exonum-build = "=1.0.0-rc.1"


### PR DESCRIPTION
This PR updates integration tests to actually use `1.0.0-rc.1` version of the crates. Thus, we ensure that the client library is actually compatible with the release.

See: https://jira.bf.local/browse/ECR-4235